### PR TITLE
Método para agregar cabezas a Geyser actualizado.

### DIFF
--- a/content/tags/faq/cabezas-geyser.conf
+++ b/content/tags/faq/cabezas-geyser.conf
@@ -7,9 +7,9 @@
     content: """
 ### Cómo permitir a usuarios Bedrock (Geyser) ver cabezas en menús Java
 1. Abre `plugins/GeyserMC/custom-skulls/custom-skulls.yml`.
-2. Busca la opción `skin-hashes`, casi al final del archivo.
-3. Aquí deberás agregar **cada** hash de las texturas de cabezas que quieres mostrar.
-  * Si estás en la página Minecraft-Heads, puedes ver el hash en la opción de "Minecraft URL". Por ejemplo: https\://textures.minecraft.net/texture/__**12d7a751eb071e08dbbc95bc5d9d66e5f51dc6712640ad2dfa03defbb68a7f3a**__
+2. Busca la opción `player-profiles`, casi al final del archivo.
+3. Aquí deberás agregar **cada** valor de las texturas de cabezas que quieres mostrar.
+  * Si estás en la página Minecraft-Heads, puedes ver el valor en la opción de "Value".
   * Recuerda separar cada head por guiones, uno debajo de otro, **sin `#` antes del guión**.
 4. Luego de haber añadido todas, reinicia el servidor.
 """,


### PR DESCRIPTION
Actualice este método para hacer mas simple el proceso de agregar cabezas, en lugar de tener que buscar el hash de la cabeza solo usas el value que usualmente usan los plugins de menús o heads.